### PR TITLE
Improving restic-helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ if you want to manually run `restic` commands against one of your
 backup profiles.  For example:
 
     # cd /etc/restic/home
-    # restic-helper restic snapshots
+    # restic-helper snapshots
     * reading configuration from /etc/restic/restic.conf
     * reading configuration from ./restic.conf
     password is correct
@@ -121,3 +121,19 @@ backup profiles.  For example:
     8938235d  2018-03-05 00:00:40  myhost  home        /home
     ----------------------------------------------------------------------
     3 snapshots
+
+When the first passed argument matches a directory under `/etc/restic`
+and there is an existing `restic.conf` inside - it will be loaded.
+For example:
+
+    # cd /
+    # restic-helper db snapshots
+    * reading configuration from /etc/restic/restic.conf
+    * reading configuration from /etc/restic/db/restic.conf
+    repository 2af0f9f5 opened successfully, password is correct
+    ID        Time                 Host    Tags        Paths
+    -----------------------------------------------------------------------
+    805h73fe  2020-05-07 01:47:23  myhost  db          /home
+    -----------------------------------------------------------------------
+    1 snapshots
+

--- a/restic-helper
+++ b/restic-helper
@@ -7,6 +7,24 @@ for conf in /etc/restic/restic.conf ./restic.conf; do
 		. $conf
 	fi
 done
+
+
+if [[ -f "/etc/restic/$1/restic.conf" ]]; then
+    echo "* reading configuration from /etc/restic/$1/restic.conf " >&2
+    . /etc/restic/$1/restic.conf
+    shift
+fi
 set +a
 
-exec "$@"
+# fallback compatibility & deprecation notice.
+if [[ $1 == "restic" ]]; then
+    BASENAME=`basename $0`
+    echo "Deprecated: $BASENAME is now a proxy to restic"
+    echo "Examples: $BASENAME snapshots"
+    echo "          $BASENAME db-config snapshots"
+    shift
+fi
+
+echo ""
+
+restic "$@"


### PR DESCRIPTION
Hi,

Thanks for making this repo public! :) 

I've been using it for a while now and decided to contribute back some improvements to the `restic-helper` script. In summary my changes:

1. make `restic-helper` act as a "direct proxy" to `restic` so that you can directly execute `restic-helper snapshots` for example.
2. if the first argument of `restic-helper` is an existing directory under `/etc/restic/*` and it contains `restic.config` (i.e. `/etc/restic/db/restic.config`) it will be loaded (example command `restic-helper db snapshots`)
3. there's a fallback check so (hopefully) existing installations shouldn't break and a deprecation warning will be shown.

If you find these changes acceptable - feel free to merge. 