### PR TITLE
Reintroduce flock

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,6 +7,7 @@ sysconfdir=/etc
 unitdir=$(sysconfdir)/systemd/system
 localstatedir=/var
 cachedir=$(localstatedir)/cache/restic
+tmpfilesdir=$(sysconfdir)/tmpfiles.d
 
 RESTIC_USER=restic
 RESTIC_GROUP=restic
@@ -73,6 +74,10 @@ install-libexec: install-libexecdir $(LIBEXECSCRIPTS)
 
 install-cachedir:
 	$(INSTALL) -d -m 750 -o $(RESTIC_USER) -g $(RESTIC_GROUP) $(cachedir)
+
+install-tmpfiles: restic-tmpfiles.conf
+	$(INSTALL) -m 755 -d $(DESTDIR)$(tmpfilesdir)
+	$(INSTALL) -m 644 restic-tmpfiles.conf $(DESTDIR)$(tmpfilesdir)/restic.conf
 
 install-restic: restic install-libexec install-bin install-cachedir
 	$(INSTALL) -m 755 restic $(bindir)/restic

--- a/restic-backup
+++ b/restic-backup
@@ -3,6 +3,14 @@
 : ${RESTIC_PRUNE_DOW:=0}
 : ${RESTIC_BIN:=/usr/libexec/restic/restic}
 : ${RESTIC_CACHE_DIR:=/var/cache/restic}
+: ${RESTIC_LOCK_FILE:=/run/restic/backup.lock}
+
+exec 200>"$RESTIC_LOCK_FILE" || exit 1
+
+if ! flock -n 200; then
+    echo "Another instance is running. Waiting..."
+    flock 200
+fi
 
 export RESTIC_CACHE_DIR
 

--- a/restic-helper
+++ b/restic-helper
@@ -2,6 +2,14 @@
 
 : ${RESTIC_BIN:=/usr/libexec/restic/restic}
 : ${RESTIC_CACHE_DIR:=/var/cache/restic}
+: ${RESTIC_LOCK_FILE:=/run/restic/helper.lock}
+
+exec 200>"$RESTIC_LOCK_FILE" || exit 1
+
+if ! flock -n 200; then
+    echo "Another instance is running. Waiting..."
+    flock 200
+fi
 
 export RESTIC_CACHE_DIR
 

--- a/restic-tmpfiles.conf.in
+++ b/restic-tmpfiles.conf.in
@@ -1,2 +1,1 @@
 D /run/restic 0700 @RESTIC_USER@ @RESTIC_GROUP@ -
-D /var/cache/restic 0700 @RESTIC_USER@ @RESTIC_GROUP@ -


### PR DESCRIPTION
This PR reintroduces `flock` to prevent `restic-backup` or `restic-helper` from failing when another instance is still running. According to the [latest README](https://github.com/larsks/restic-systemd-units/tree/a386c9526f156f6c4dd67d621392d4d091a089a2), this is the expected behavior, however, flock was removed from the systemd units in https://github.com/larsks/restic-systemd-units/commit/b63f2be98e92eaa5053d53e74ad998af0e4ec8f5 without further explanation.

I assume that this was done by accident, so I’m reintroducing flock with this PR. Please let me know if I’m missing something.

Note that I’m adding `flock` to the wrapper scripts `restic-backup` and `restic-helper` as I feel it’s cleaner to have it there. Also, a message will be printed to stdout if another instance is still running.

Additionally, I’m adding an install step for `restic-tmpfiles.conf` to the Makefile, so the `/run/restic` directory gets created with appropriate permissions. This was also removed in b63f2be98e92eaa5053d53e74ad998af0e4ec8f5.

Finally, I have removed `/var/cache/restic` from `restic-tmpfiles.conf.in` since the Makefile now contains a step to create it.